### PR TITLE
Update Maven Shade Plugin version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add the following shading section to prevent class loader conflicts:
     <plugin>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-shade-plugin</artifactId>
-      <version>3.2.4</version>
+      <version>3.3.0</version>
       <configuration>
         <relocations>
           <relocation>


### PR DESCRIPTION
- Update maven-shade-plugin version in README.md from 3.2.4 to 3.3.0 (supports java 17)