### PR TITLE
[Feature] Allow preservation of original scalar and flow styles

### DIFF
--- a/src/main/java/dev/dejvokep/boostedyaml/block/Block.java
+++ b/src/main/java/dev/dejvokep/boostedyaml/block/Block.java
@@ -22,7 +22,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.snakeyaml.engine.v2.comments.CommentLine;
 import org.snakeyaml.engine.v2.comments.CommentType;
+import org.snakeyaml.engine.v2.common.FlowStyle;
 import org.snakeyaml.engine.v2.common.ScalarStyle;
+import org.snakeyaml.engine.v2.nodes.CollectionNode;
 import org.snakeyaml.engine.v2.nodes.MappingNode;
 import org.snakeyaml.engine.v2.nodes.Node;
 import org.snakeyaml.engine.v2.nodes.NodeTuple;
@@ -47,6 +49,9 @@ public abstract class Block<T> {
     //Original scalar styles as loaded from the file
     @Nullable
     private ScalarStyle originalKeyStyle = null, originalValueStyle = null;
+    //Original flow style of the value collection (sequence/mapping) as loaded from the file
+    @Nullable
+    private FlowStyle originalValueFlowStyle = null;
     //Value
     private T value;
     //If to ignore
@@ -133,6 +138,9 @@ public abstract class Block<T> {
             // Capture original scalar style
             if (value instanceof ScalarNode)
                 originalValueStyle = ((ScalarNode) value).getScalarStyle();
+            // Capture original flow style
+            if (value instanceof CollectionNode)
+                originalValueFlowStyle = ((CollectionNode<?>) value).getFlowStyle();
         }
     }
 
@@ -156,6 +164,18 @@ public abstract class Block<T> {
     @Nullable
     public ScalarStyle getOriginalValueStyle() {
         return originalValueStyle;
+    }
+
+    /**
+     * Returns the flow style of the value collection (sequence or mapping), exactly as it was loaded from the file; or
+     * <code>null</code> if this block's value was not loaded from a collection node (e.g. was created programmatically,
+     * or is a scalar).
+     *
+     * @return the original value flow style, or <code>null</code>
+     */
+    @Nullable
+    public FlowStyle getOriginalValueFlowStyle() {
+        return originalValueFlowStyle;
     }
 
     /**

--- a/src/main/java/dev/dejvokep/boostedyaml/block/Block.java
+++ b/src/main/java/dev/dejvokep/boostedyaml/block/Block.java
@@ -52,6 +52,9 @@ public abstract class Block<T> {
     //Original flow style of the value collection (sequence/mapping) as loaded from the file
     @Nullable
     private FlowStyle originalValueFlowStyle = null;
+    //Original value node, kept for replaying styles of nested scalars/collections (not retained by sections)
+    @Nullable
+    private Node originalValueNode = null;
     //Value
     private T value;
     //If to ignore
@@ -102,6 +105,10 @@ public abstract class Block<T> {
         this.beforeValueComments = previous.beforeValueComments;
         this.inlineValueComments = previous.inlineValueComments;
         this.afterValueComments = previous.afterValueComments;
+        this.originalKeyStyle = previous.originalKeyStyle;
+        this.originalValueStyle = previous.originalValueStyle;
+        this.originalValueFlowStyle = previous.originalValueFlowStyle;
+        this.originalValueNode = previous.originalValueNode;
     }
 
     /**
@@ -141,7 +148,16 @@ public abstract class Block<T> {
             // Capture original flow style
             if (value instanceof CollectionNode)
                 originalValueFlowStyle = ((CollectionNode<?>) value).getFlowStyle();
+            originalValueNode = value;
         }
+    }
+
+    /**
+     * Discards the reference to the original value node. Used by {@link Section sections}, which build child blocks from
+     * the node and do not need to retain the (potentially large) node tree afterwards.
+     */
+    protected void discardOriginalValueNode() {
+        originalValueNode = null;
     }
 
     /**
@@ -176,6 +192,20 @@ public abstract class Block<T> {
     @Nullable
     public FlowStyle getOriginalValueFlowStyle() {
         return originalValueFlowStyle;
+    }
+
+    /**
+     * Returns the value node, exactly as it was loaded from the file; or <code>null</code> if this block was not loaded
+     * from a file, or the node was discarded (as is the case for {@link Section sections}).
+     * <p>
+     * Used to replay the styles of scalars and collections nested within the value (e.g. the elements of a sequence),
+     * which are not stored as blocks of their own.
+     *
+     * @return the original value node, or <code>null</code>
+     */
+    @Nullable
+    public Node getOriginalValueNode() {
+        return originalValueNode;
     }
 
     /**

--- a/src/main/java/dev/dejvokep/boostedyaml/block/Block.java
+++ b/src/main/java/dev/dejvokep/boostedyaml/block/Block.java
@@ -22,9 +22,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.snakeyaml.engine.v2.comments.CommentLine;
 import org.snakeyaml.engine.v2.comments.CommentType;
+import org.snakeyaml.engine.v2.common.ScalarStyle;
 import org.snakeyaml.engine.v2.nodes.MappingNode;
 import org.snakeyaml.engine.v2.nodes.Node;
 import org.snakeyaml.engine.v2.nodes.NodeTuple;
+import org.snakeyaml.engine.v2.nodes.ScalarNode;
 import org.snakeyaml.engine.v2.nodes.SequenceNode;
 
 import java.util.ArrayList;
@@ -42,6 +44,9 @@ public abstract class Block<T> {
     //Comments
     @Nullable
     List<CommentLine> beforeKeyComments = null, inlineKeyComments = null, afterKeyComments = null, beforeValueComments = null, inlineValueComments = null, afterValueComments = null;
+    //Original scalar styles as loaded from the file
+    @Nullable
+    private ScalarStyle originalKeyStyle = null, originalValueStyle = null;
     //Value
     private T value;
     //If to ignore
@@ -112,6 +117,9 @@ public abstract class Block<T> {
             afterKeyComments = key.getEndComments();
             // Collect
             collectComments(key, beforeKeyComments, true);
+            // Capture original scalar style
+            if (key instanceof ScalarNode)
+                originalKeyStyle = ((ScalarNode) key).getScalarStyle();
         }
 
         //If not null
@@ -122,7 +130,32 @@ public abstract class Block<T> {
             afterValueComments = value.getEndComments();
             // Collect
             collectComments(value, beforeValueComments, true);
+            // Capture original scalar style
+            if (value instanceof ScalarNode)
+                originalValueStyle = ((ScalarNode) value).getScalarStyle();
         }
+    }
+
+    /**
+     * Returns the scalar style of the key node, exactly as it was loaded from the file; or <code>null</code> if this
+     * block was not loaded from a scalar key node (e.g. was created programmatically).
+     *
+     * @return the original key scalar style, or <code>null</code>
+     */
+    @Nullable
+    public ScalarStyle getOriginalKeyStyle() {
+        return originalKeyStyle;
+    }
+
+    /**
+     * Returns the scalar style of the value node, exactly as it was loaded from the file; or <code>null</code> if this
+     * block was not loaded from a scalar value node (e.g. was created programmatically, or represents a section).
+     *
+     * @return the original value scalar style, or <code>null</code>
+     */
+    @Nullable
+    public ScalarStyle getOriginalValueStyle() {
+        return originalValueStyle;
     }
 
     /**

--- a/src/main/java/dev/dejvokep/boostedyaml/block/implementation/Section.java
+++ b/src/main/java/dev/dejvokep/boostedyaml/block/implementation/Section.java
@@ -218,6 +218,7 @@ public class Section extends Block<Map<Object, Block<?>>> {
                     new Section(root, this, getSubRoute(key), tuple.getKeyNode(), (MappingNode) tuple.getValueNode(), constructor) :
                     new TerminatedBlock(tuple.getKeyNode(), tuple.getValueNode(), value));
         }
+        discardOriginalValueNode();
     }
 
     /**

--- a/src/main/java/dev/dejvokep/boostedyaml/engine/ExtendedRepresenter.java
+++ b/src/main/java/dev/dejvokep/boostedyaml/engine/ExtendedRepresenter.java
@@ -50,6 +50,8 @@ public class ExtendedRepresenter extends StandardRepresenter {
 
     //Currently serialized node role
     private NodeRole nodeRole = NodeRole.KEY;
+    //Original scalar styles of the block currently being serialized
+    private ScalarStyle originalKeyStyle = null, originalValueStyle = null;
 
     /**
      * Creates an instance of the representer.
@@ -98,6 +100,14 @@ public class ExtendedRepresenter extends StandardRepresenter {
 
     @Override
     protected Node representScalar(Tag tag, String value, ScalarStyle scalarStyle) {
+        // When preservation is enabled and the original style is known, use it as the default passed to the formatter
+        if (dumperSettings.isPreserveScalarStyle()) {
+            ScalarStyle original = nodeRole == NodeRole.KEY ? originalKeyStyle : originalValueStyle;
+            if (original != null) {
+                ScalarStyle formatted = dumperSettings.getScalarFormatter().format(tag, value, nodeRole, original);
+                return new ScalarNode(tag, value, formatted);
+            }
+        }
         return super.representScalar(tag, value, dumperSettings.getScalarFormatter().format(tag, value, nodeRole, scalarStyle));
     }
 
@@ -245,6 +255,9 @@ public class ExtendedRepresenter extends StandardRepresenter {
     protected NodeTuple representMappingEntry(Map.Entry<?, ?> entry) {
         //Block
         Block<?> block = entry.getValue() instanceof Block ? (Block<?>) entry.getValue() : null;
+        //Stash original scalar styles for this block
+        originalKeyStyle = block == null ? null : block.getOriginalKeyStyle();
+        originalValueStyle = block == null ? null : block.getOriginalValueStyle();
         //Represent nodes
         Node key = applyComments(block, nodeRole = NodeRole.KEY, representData(entry.getKey()), false);
         Node value = applyComments(block, nodeRole = NodeRole.VALUE, representData(block == null ? entry.getValue() : block.getStoredValue()), false);

--- a/src/main/java/dev/dejvokep/boostedyaml/engine/ExtendedRepresenter.java
+++ b/src/main/java/dev/dejvokep/boostedyaml/engine/ExtendedRepresenter.java
@@ -33,7 +33,10 @@ import org.snakeyaml.engine.v2.common.ScalarStyle;
 import org.snakeyaml.engine.v2.nodes.*;
 import org.snakeyaml.engine.v2.representer.StandardRepresenter;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 
@@ -50,10 +53,12 @@ public class ExtendedRepresenter extends StandardRepresenter {
 
     //Currently serialized node role
     private NodeRole nodeRole = NodeRole.KEY;
-    //Original scalar styles of the block currently being serialized
+    //Original key and value scalar styles of the block currently being serialized
     private ScalarStyle originalKeyStyle = null, originalValueStyle = null;
-    //Original flow style of the value collection currently being serialized
+    //Original flow style of a section value currently being serialized
     private FlowStyle originalValueFlowStyle = null;
+    //Pre-order styles of the value subtree currently being serialized, replayed for its nested scalars/collections
+    private Deque<Enum<?>> valueStyles = null;
 
     /**
      * Creates an instance of the representer.
@@ -102,14 +107,24 @@ public class ExtendedRepresenter extends StandardRepresenter {
 
     @Override
     protected Node representScalar(Tag tag, String value, ScalarStyle scalarStyle) {
-        // When preservation is enabled and the original style is known, use it as the default passed to the formatter
+        // Replaying styles of a value subtree (e.g. the elements of a sequence)
+        if (valueStyles != null) {
+            if (valueStyles.peekFirst() instanceof ScalarStyle) {
+                ScalarStyle original = (ScalarStyle) valueStyles.pollFirst();
+                if (dumperSettings.isPreserveScalarStyle())
+                    return new ScalarNode(tag, value, dumperSettings.getScalarFormatter().format(tag, value, nodeRole, original));
+                return super.representScalar(tag, value, dumperSettings.getScalarFormatter().format(tag, value, nodeRole, scalarStyle));
+            }
+            valueStyles = null;
+        }
+
+        // The key, and a value with no node to replay (e.g. one replaced via a set), keep their block-level style here
         if (dumperSettings.isPreserveScalarStyle()) {
             ScalarStyle original = nodeRole == NodeRole.KEY ? originalKeyStyle : originalValueStyle;
-            if (original != null) {
-                ScalarStyle formatted = dumperSettings.getScalarFormatter().format(tag, value, nodeRole, original);
-                return new ScalarNode(tag, value, formatted);
-            }
+            if (original != null)
+                return new ScalarNode(tag, value, dumperSettings.getScalarFormatter().format(tag, value, nodeRole, original));
         }
+
         return super.representScalar(tag, value, dumperSettings.getScalarFormatter().format(tag, value, nodeRole, scalarStyle));
     }
 
@@ -125,22 +140,78 @@ public class ExtendedRepresenter extends StandardRepresenter {
 
     /**
      * Returns the default flow style to hand to the formatter for the collection currently being serialized. When flow
-     * style preservation is enabled and the collection was loaded with a known style, that style is returned; otherwise
-     * the given configured style is returned.
-     * <p>
-     * The captured style is consumed on use, so collections nested within this one (which have no captured style of
-     * their own) fall back to the configured style instead of inheriting this one.
+     * style preservation is enabled, this is the style the collection was loaded with (taken from the value subtree
+     * replay, or from a section's stored style); otherwise the given configured style is returned.
      *
      * @param configured the configured flow style
      * @return the flow style to use as the default
      */
     private FlowStyle preserveFlowStyle(FlowStyle configured) {
+        // Replaying styles of a value subtree
+        if (valueStyles != null) {
+            if (valueStyles.peekFirst() instanceof FlowStyle) {
+                FlowStyle original = (FlowStyle) valueStyles.pollFirst();
+                return dumperSettings.isPreserveFlowStyle() ? original : configured;
+            }
+            // The value no longer matches the loaded node - stop replaying and fall back
+            valueStyles = null;
+        }
+
+        // Section values keep their flow style here, since they are not replayed from a node
         if (dumperSettings.isPreserveFlowStyle() && originalValueFlowStyle != null) {
             FlowStyle original = originalValueFlowStyle;
             originalValueFlowStyle = null;
             return original;
         }
         return configured;
+    }
+
+    /**
+     * Collects the scalar and flow styles of the given node and all its descendants in pre-order (the same order in
+     * which they are serialized), so they can be replayed onto the produced nodes.
+     *
+     * @param node the value node to collect styles from
+     * @return the collected styles, oldest first
+     */
+    private Deque<Enum<?>> collectStyles(@NotNull Node node) {
+        Deque<Enum<?>> styles = new ArrayDeque<>();
+        collectStyles(node, styles);
+        return styles;
+    }
+
+    /**
+     * Returns whether the given value node still matches the given value, i.e. they are the same kind and, for
+     * collections, the same size. Used to decide whether a value replaced via a set can have its per-element styles
+     * replayed - a replacement of a different shape cannot be aligned positionally.
+     *
+     * @param node  the original value node
+     * @param value the current value
+     * @return whether the styles of the node can be replayed onto the value
+     */
+    private boolean nodeMatchesValue(@NotNull Node node, @Nullable Object value) {
+        if (node instanceof ScalarNode)
+            return !(value instanceof Collection) && !(value instanceof Map);
+        if (node instanceof SequenceNode)
+            return value instanceof Collection && ((Collection<?>) value).size() == ((SequenceNode) node).getValue().size();
+        if (node instanceof MappingNode)
+            return value instanceof Map && ((Map<?, ?>) value).size() == ((MappingNode) node).getValue().size();
+        return false;
+    }
+
+    private void collectStyles(@NotNull Node node, @NotNull Deque<Enum<?>> styles) {
+        if (node instanceof ScalarNode) {
+            styles.addLast(((ScalarNode) node).getScalarStyle());
+        } else if (node instanceof SequenceNode) {
+            styles.addLast(((SequenceNode) node).getFlowStyle());
+            for (Node element : ((SequenceNode) node).getValue())
+                collectStyles(element, styles);
+        } else if (node instanceof MappingNode) {
+            styles.addLast(((MappingNode) node).getFlowStyle());
+            for (NodeTuple tuple : ((MappingNode) node).getValue()) {
+                collectStyles(tuple.getKeyNode(), styles);
+                collectStyles(tuple.getValueNode(), styles);
+            }
+        }
     }
 
     /**
@@ -275,15 +346,30 @@ public class ExtendedRepresenter extends StandardRepresenter {
 
     @Override
     protected NodeTuple representMappingEntry(Map.Entry<?, ?> entry) {
+        // Entry of a plain map nested within a value subtree - styles are supplied by the active replay
+        if (valueStyles != null) {
+            Node replayedKey = representData(entry.getKey());
+            Node replayedValue = representData(entry.getValue());
+            return new NodeTuple(replayedKey, replayedValue);
+        }
+
         //Block
         Block<?> block = entry.getValue() instanceof Block ? (Block<?>) entry.getValue() : null;
         //Stash original styles for this block
         originalKeyStyle = block == null ? null : block.getOriginalKeyStyle();
         originalValueStyle = block == null ? null : block.getOriginalValueStyle();
         originalValueFlowStyle = block == null ? null : block.getOriginalValueFlowStyle();
-        //Represent nodes
+        //Represent the key (before the value subtree replay is active)
         Node key = applyComments(block, nodeRole = NodeRole.KEY, representData(entry.getKey()), false);
+        boolean replaying = block != null && block.getOriginalValueNode() != null
+                && (dumperSettings.isPreserveScalarStyle() || dumperSettings.isPreserveFlowStyle())
+                && nodeMatchesValue(block.getOriginalValueNode(), block.getStoredValue());
+        if (replaying)
+            valueStyles = collectStyles(block.getOriginalValueNode());
+        //Represent the value
         Node value = applyComments(block, nodeRole = NodeRole.VALUE, representData(block == null ? entry.getValue() : block.getStoredValue()), false);
+        if (replaying)
+            valueStyles = null;
         //Create
         return new NodeTuple(key, value);
     }

--- a/src/main/java/dev/dejvokep/boostedyaml/engine/ExtendedRepresenter.java
+++ b/src/main/java/dev/dejvokep/boostedyaml/engine/ExtendedRepresenter.java
@@ -52,6 +52,8 @@ public class ExtendedRepresenter extends StandardRepresenter {
     private NodeRole nodeRole = NodeRole.KEY;
     //Original scalar styles of the block currently being serialized
     private ScalarStyle originalKeyStyle = null, originalValueStyle = null;
+    //Original flow style of the value collection currently being serialized
+    private FlowStyle originalValueFlowStyle = null;
 
     /**
      * Creates an instance of the representer.
@@ -113,12 +115,32 @@ public class ExtendedRepresenter extends StandardRepresenter {
 
     @Override
     protected Node representSequence(Tag tag, Iterable<?> sequence, FlowStyle flowStyle) {
-        return super.representSequence(tag, sequence, dumperSettings.getSequenceFormatter().format(tag, sequence, nodeRole, flowStyle));
+        return super.representSequence(tag, sequence, dumperSettings.getSequenceFormatter().format(tag, sequence, nodeRole, preserveFlowStyle(flowStyle)));
     }
 
     @Override
     protected Node representMapping(Tag tag, Map<?, ?> mapping, FlowStyle flowStyle) {
-        return super.representMapping(tag, mapping, dumperSettings.getMappingFormatter().format(tag, mapping, nodeRole, flowStyle));
+        return super.representMapping(tag, mapping, dumperSettings.getMappingFormatter().format(tag, mapping, nodeRole, preserveFlowStyle(flowStyle)));
+    }
+
+    /**
+     * Returns the default flow style to hand to the formatter for the collection currently being serialized. When flow
+     * style preservation is enabled and the collection was loaded with a known style, that style is returned; otherwise
+     * the given configured style is returned.
+     * <p>
+     * The captured style is consumed on use, so collections nested within this one (which have no captured style of
+     * their own) fall back to the configured style instead of inheriting this one.
+     *
+     * @param configured the configured flow style
+     * @return the flow style to use as the default
+     */
+    private FlowStyle preserveFlowStyle(FlowStyle configured) {
+        if (dumperSettings.isPreserveFlowStyle() && originalValueFlowStyle != null) {
+            FlowStyle original = originalValueFlowStyle;
+            originalValueFlowStyle = null;
+            return original;
+        }
+        return configured;
     }
 
     /**
@@ -255,9 +277,10 @@ public class ExtendedRepresenter extends StandardRepresenter {
     protected NodeTuple representMappingEntry(Map.Entry<?, ?> entry) {
         //Block
         Block<?> block = entry.getValue() instanceof Block ? (Block<?>) entry.getValue() : null;
-        //Stash original scalar styles for this block
+        //Stash original styles for this block
         originalKeyStyle = block == null ? null : block.getOriginalKeyStyle();
         originalValueStyle = block == null ? null : block.getOriginalValueStyle();
+        originalValueFlowStyle = block == null ? null : block.getOriginalValueFlowStyle();
         //Represent nodes
         Node key = applyComments(block, nodeRole = NodeRole.KEY, representData(entry.getKey()), false);
         Node value = applyComments(block, nodeRole = NodeRole.VALUE, representData(block == null ? entry.getValue() : block.getStoredValue()), false);

--- a/src/main/java/dev/dejvokep/boostedyaml/settings/dumper/DumperSettings.java
+++ b/src/main/java/dev/dejvokep/boostedyaml/settings/dumper/DumperSettings.java
@@ -81,6 +81,8 @@ public class DumperSettings implements Settings {
     private final ScalarStyle stringStyle;
     //If to preserve original scalar styles as loaded from the file
     private final boolean preserveScalarStyle;
+    //If to preserve original flow styles as loaded from the file
+    private final boolean preserveFlowStyle;
     //Formatters
     private final Formatter<ScalarStyle, String> scalarFormatter;
     private final Formatter<FlowStyle, Iterable<?>> sequenceFormatter;
@@ -99,6 +101,7 @@ public class DumperSettings implements Settings {
         this.mappingFormatter = builder.mappingFormatter;
         this.stringStyle = builder.stringStyle;
         this.preserveScalarStyle = builder.preserveScalarStyle;
+        this.preserveFlowStyle = builder.preserveFlowStyle;
     }
 
     /**
@@ -136,6 +139,16 @@ public class DumperSettings implements Settings {
      */
     public boolean isPreserveScalarStyle() {
         return preserveScalarStyle;
+    }
+
+    /**
+     * Returns whether original flow styles (as loaded from the file) are preserved and passed to the sequence and
+     * mapping formatters as the default style, instead of the configured flow style.
+     *
+     * @return if to preserve original flow styles
+     */
+    public boolean isPreserveFlowStyle() {
+        return preserveFlowStyle;
     }
 
     /**
@@ -230,6 +243,10 @@ public class DumperSettings implements Settings {
          */
         public static final boolean DEFAULT_PRESERVE_SCALAR_STYLE = false;
         /**
+         * If to preserve original flow styles by default.
+         */
+        public static final boolean DEFAULT_PRESERVE_FLOW_STYLE = false;
+        /**
          * If to add document start by default.
          */
         public static final boolean DEFAULT_START_MARKER = false;
@@ -286,6 +303,8 @@ public class DumperSettings implements Settings {
         private ScalarStyle stringStyle = DEFAULT_STRING_STYLE;
         //If to preserve original scalar styles
         private boolean preserveScalarStyle = DEFAULT_PRESERVE_SCALAR_STYLE;
+        //If to preserve original flow styles
+        private boolean preserveFlowStyle = DEFAULT_PRESERVE_FLOW_STYLE;
 
         /**
          * Creates a new builder from the given, already created SnakeYAML Engine settings builder.
@@ -439,6 +458,30 @@ public class DumperSettings implements Settings {
          */
         public Builder setPreserveScalarStyle(boolean preserve) {
             this.preserveScalarStyle = preserve;
+            return this;
+        }
+
+        /**
+         * Sets whether to preserve the original flow styles, exactly as they were loaded from the file.
+         * <p>
+         * When enabled, the flow style a sequence or mapping node was loaded with is passed to the respective
+         * {@link #setSequenceFormatter(Formatter) sequence} or {@link #setMappingFormatter(Formatter) mapping} formatter
+         * as the <i>default</i> style (the last parameter), instead of the configured {@link #setFlowStyle(FlowStyle)
+         * flow} style. The formatter still has the final say and may override it. Using the default (identity) formatter
+         * therefore reproduces the original styling.
+         * <p>
+         * This only affects collections that were actually loaded from a file. Values created or modified
+         * programmatically, as well as collections nested within another collection's value, have no original style and
+         * fall back to the configured flow style. Styles returned might still be overridden to produce output compliant
+         * with the YAML specification.
+         * <p>
+         * <b>Default: </b> {@link #DEFAULT_PRESERVE_FLOW_STYLE}
+         *
+         * @param preserve if to preserve original flow styles
+         * @return the builder
+         */
+        public Builder setPreserveFlowStyle(boolean preserve) {
+            this.preserveFlowStyle = preserve;
             return this;
         }
 

--- a/src/main/java/dev/dejvokep/boostedyaml/settings/dumper/DumperSettings.java
+++ b/src/main/java/dev/dejvokep/boostedyaml/settings/dumper/DumperSettings.java
@@ -79,6 +79,8 @@ public class DumperSettings implements Settings {
     private final Supplier<AnchorGenerator> generatorSupplier;
     //String style
     private final ScalarStyle stringStyle;
+    //If to preserve original scalar styles as loaded from the file
+    private final boolean preserveScalarStyle;
     //Formatters
     private final Formatter<ScalarStyle, String> scalarFormatter;
     private final Formatter<FlowStyle, Iterable<?>> sequenceFormatter;
@@ -96,6 +98,7 @@ public class DumperSettings implements Settings {
         this.sequenceFormatter = builder.sequenceFormatter;
         this.mappingFormatter = builder.mappingFormatter;
         this.stringStyle = builder.stringStyle;
+        this.preserveScalarStyle = builder.preserveScalarStyle;
     }
 
     /**
@@ -123,6 +126,16 @@ public class DumperSettings implements Settings {
      */
     public Formatter<ScalarStyle, String> getScalarFormatter() {
         return scalarFormatter;
+    }
+
+    /**
+     * Returns whether original scalar styles (as loaded from the file) are preserved and passed to the scalar formatter
+     * as the default style, instead of the configured {@link #getScalarFormatter() scalar} style.
+     *
+     * @return if to preserve original scalar styles
+     */
+    public boolean isPreserveScalarStyle() {
+        return preserveScalarStyle;
     }
 
     /**
@@ -213,6 +226,10 @@ public class DumperSettings implements Settings {
          */
         public static final ScalarStyle DEFAULT_STRING_STYLE = ScalarStyle.PLAIN;
         /**
+         * If to preserve original scalar styles by default.
+         */
+        public static final boolean DEFAULT_PRESERVE_SCALAR_STYLE = false;
+        /**
          * If to add document start by default.
          */
         public static final boolean DEFAULT_START_MARKER = false;
@@ -267,6 +284,8 @@ public class DumperSettings implements Settings {
         private Formatter<FlowStyle, Map<?, ?>> mappingFormatter = DEFAULT_MAPPING_FORMATTER;
         //String style
         private ScalarStyle stringStyle = DEFAULT_STRING_STYLE;
+        //If to preserve original scalar styles
+        private boolean preserveScalarStyle = DEFAULT_PRESERVE_SCALAR_STYLE;
 
         /**
          * Creates a new builder from the given, already created SnakeYAML Engine settings builder.
@@ -398,6 +417,28 @@ public class DumperSettings implements Settings {
          */
         public Builder setScalarFormatter(@NotNull Formatter<ScalarStyle, String> formatter) {
             this.scalarFormatter = formatter;
+            return this;
+        }
+
+        /**
+         * Sets whether to preserve the original scalar styles, exactly as they were loaded from the file.
+         * <p>
+         * When enabled, the style a scalar node was loaded with is passed to the {@link #setScalarFormatter(Formatter)
+         * scalar formatter} as the <i>default</i> style (the last parameter), instead of the configured
+         * {@link #setScalarStyle(ScalarStyle) scalar} style. The formatter still has the final say and may override it.
+         * Using the default (identity) formatter therefore reproduces the original styling.
+         * <p>
+         * This only affects scalars that were actually loaded from a file. Values created or modified programmatically
+         * have no original style and fall back to the configured scalar style. Styles returned might still be overridden
+         * to produce output compliant with the YAML specification.
+         * <p>
+         * <b>Default: </b> {@link #DEFAULT_PRESERVE_SCALAR_STYLE}
+         *
+         * @param preserve if to preserve original scalar styles
+         * @return the builder
+         */
+        public Builder setPreserveScalarStyle(boolean preserve) {
+            this.preserveScalarStyle = preserve;
             return this;
         }
 

--- a/src/test/java/dev/dejvokep/boostedyaml/engine/ExtendedRepresenterTest.java
+++ b/src/test/java/dev/dejvokep/boostedyaml/engine/ExtendedRepresenterTest.java
@@ -354,6 +354,23 @@ class ExtendedRepresenterTest {
     }
 
     @Test
+    void representPreserveFlowStyle() throws IOException {
+        String yaml = "flowList: [a, b]\nblockList:\n- c\n- d\nflowMap: {x: 1}\nblockMap:\n  y: 2\n";
+
+        // On: each collection keeps the style it was loaded with, even though the configured style is BLOCK
+        DumperSettings preserve = DumperSettings.builder().setFlowStyle(FlowStyle.BLOCK).setPreserveFlowStyle(true).build();
+        assertEquals(yaml, YamlDocument.create(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))).dump(preserve));
+
+        // Off: everything drops to the configured block style
+        DumperSettings off = DumperSettings.builder().setFlowStyle(FlowStyle.BLOCK).setPreserveFlowStyle(false).build();
+        assertEquals("flowList:\n- a\n- b\nblockList:\n- c\n- d\nflowMap:\n  x: 1\nblockMap:\n  y: 2\n", YamlDocument.create(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))).dump(off));
+
+        // A formatter still has the last word over the preserved style
+        DumperSettings override = DumperSettings.builder().setFlowStyle(FlowStyle.BLOCK).setPreserveFlowStyle(true).setSequenceFormatter((tag, value, role, def) -> FlowStyle.BLOCK).build();
+        assertEquals("flowList:\n- a\n- b\nblockList:\n- c\n- d\nflowMap: {x: 1}\nblockMap:\n  y: 2\n", YamlDocument.create(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))).dump(override));
+    }
+
+    @Test
     void representSequence() throws IOException {
         DumperSettings settings = DumperSettings.builder().setFlowStyle(FlowStyle.BLOCK).setSequenceFormatter(((tag, value, role, def) -> value.iterator().next().toString().equals("a") ? FlowStyle.FLOW : def)).build();
         YamlDocument document = YamlDocument.create(new ByteArrayInputStream("flow:\n- a\n- b\n- c\nblock: [d, e, f]".getBytes(StandardCharsets.UTF_8)), settings);

--- a/src/test/java/dev/dejvokep/boostedyaml/engine/ExtendedRepresenterTest.java
+++ b/src/test/java/dev/dejvokep/boostedyaml/engine/ExtendedRepresenterTest.java
@@ -337,6 +337,23 @@ class ExtendedRepresenterTest {
     }
 
     @Test
+    void representScalarPreserveStyle() throws IOException {
+        String yaml = "k1: \"double\"\nk2: 'single'\nk3: plain\n\"k4\": v\n";
+
+        // On: keep the original styles even though string style says single quote everything
+        DumperSettings preserve = DumperSettings.builder().setFlowStyle(FlowStyle.BLOCK).setStringStyle(ScalarStyle.SINGLE_QUOTED).setPreserveScalarStyle(true).build();
+        assertEquals(yaml, YamlDocument.create(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))).dump(preserve));
+
+        // Off: string style takes over
+        DumperSettings off = DumperSettings.builder().setFlowStyle(FlowStyle.BLOCK).setStringStyle(ScalarStyle.SINGLE_QUOTED).setPreserveScalarStyle(false).build();
+        assertEquals("'k1': 'double'\n'k2': 'single'\n'k3': 'plain'\n'k4': 'v'\n", YamlDocument.create(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))).dump(off));
+
+        // A formatter still has the last word over the preserved style
+        DumperSettings override = DumperSettings.builder().setFlowStyle(FlowStyle.BLOCK).setPreserveScalarStyle(true).setScalarFormatter((tag, value, role, def) -> ScalarStyle.PLAIN).build();
+        assertEquals("k1: double\nk2: single\nk3: plain\nk4: v\n", YamlDocument.create(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))).dump(override));
+    }
+
+    @Test
     void representSequence() throws IOException {
         DumperSettings settings = DumperSettings.builder().setFlowStyle(FlowStyle.BLOCK).setSequenceFormatter(((tag, value, role, def) -> value.iterator().next().toString().equals("a") ? FlowStyle.FLOW : def)).build();
         YamlDocument document = YamlDocument.create(new ByteArrayInputStream("flow:\n- a\n- b\n- c\nblock: [d, e, f]".getBytes(StandardCharsets.UTF_8)), settings);

--- a/src/test/java/dev/dejvokep/boostedyaml/engine/ExtendedRepresenterTest.java
+++ b/src/test/java/dev/dejvokep/boostedyaml/engine/ExtendedRepresenterTest.java
@@ -37,6 +37,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -354,6 +355,31 @@ class ExtendedRepresenterTest {
     }
 
     @Test
+    void representPreserveStyleAfterSet() throws IOException {
+        DumperSettings preserve = DumperSettings.builder().setPreserveScalarStyle(true).build();
+        YamlDocument document = YamlDocument.create(new ByteArrayInputStream("\"key\": \"old\"\n".getBytes(StandardCharsets.UTF_8)), preserve);
+        document.set("key", "new");
+        // A value replaced via a set keeps both the key's and the previous value's style
+        assertEquals("\"key\": \"new\"\n", document.dump());
+    }
+
+    @Test
+    void representPreserveListStyleAfterSet() throws IOException {
+        String yaml = "items:\n- 'a'\n- \"b\"\n";
+        DumperSettings preserve = DumperSettings.builder().setPreserveScalarStyle(true).setPreserveFlowStyle(true).build();
+
+        // Same size: each element keeps the style of the element it replaced, positionally
+        YamlDocument same = YamlDocument.create(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)), preserve);
+        same.set("items", Arrays.asList("x", "y"));
+        assertEquals("items:\n- 'x'\n- \"y\"\n", same.dump());
+
+        // Different size: cannot align, so the whole list falls back to the configured style
+        YamlDocument diff = YamlDocument.create(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)), preserve);
+        diff.set("items", Arrays.asList("x", "y", "z"));
+        assertEquals("items:\n- x\n- y\n- z\n", diff.dump());
+    }
+
+    @Test
     void representPreserveFlowStyle() throws IOException {
         String yaml = "flowList: [a, b]\nblockList:\n- c\n- d\nflowMap: {x: 1}\nblockMap:\n  y: 2\n";
 
@@ -368,6 +394,29 @@ class ExtendedRepresenterTest {
         // A formatter still has the last word over the preserved style
         DumperSettings override = DumperSettings.builder().setFlowStyle(FlowStyle.BLOCK).setPreserveFlowStyle(true).setSequenceFormatter((tag, value, role, def) -> FlowStyle.BLOCK).build();
         assertEquals("flowList:\n- a\n- b\nblockList:\n- c\n- d\nflowMap: {x: 1}\nblockMap:\n  y: 2\n", YamlDocument.create(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))).dump(override));
+    }
+
+    @Test
+    void representPreserveNestedStyle() throws IOException {
+        // Styles nested inside sequences and mappings (not stored as blocks of their own) are preserved too
+        String yaml = "name: \"double quoted\"\n" +
+                "nick: 'single quoted'\n" +
+                "plain: value\n" +
+                "count: 5\n" +
+                "messages:\n" +
+                "- \"first\"\n" +
+                "- \"second\"\n" +
+                "- 'third'\n" +
+                "tags: [alpha, beta]\n" +
+                "nested:\n" +
+                "  key: \"quoted\"\n" +
+                "  flow: {a: 1, b: 2}\n" +
+                "matrix:\n" +
+                "- [1, 2]\n" +
+                "- [3, 4]\n";
+
+        DumperSettings preserve = DumperSettings.builder().setPreserveScalarStyle(true).setPreserveFlowStyle(true).build();
+        assertEquals(yaml, YamlDocument.create(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)), preserve).dump());
     }
 
     @Test


### PR DESCRIPTION
Loading a document and dumping it back currently loses the original scalar quoting and flow styles, so everything comes out in whatever style the dumper is set to. This adds two opt-in settings to keep them the way they were in the file:

- `setPreserveScalarStyle(true)` keeps plain/single/double/literal/folded per scalar
- `setPreserveFlowStyle(true)` keeps block vs flow per sequence and mapping

Both default to `false` so nothing changes unless you turn them on. The style a node was loaded with gets captured on the block and passed to the formatter as its default value, so a custom formatter can still override it. Only nodes actually read from a file carry a style. Values set in code, and collections nested inside another collection's value, fall back to the configured style. Styles can still be adjusted where needed to stay spec-compliant, same as before.

```java
DumperSettings dumper = DumperSettings.builder()
        .setPreserveScalarStyle(true)
        .setPreserveFlowStyle(true)
        .build();
```

Added tests for this in `ExtendedRepresenterTest`.
